### PR TITLE
Fix percentage calculator with missing price

### DIFF
--- a/fetch-prices.js
+++ b/fetch-prices.js
@@ -42,7 +42,9 @@ async function getPrice(url) {
 }
 
 const pct = (self, other) =>
-  other ? (((self - other) / other) * 100).toFixed(1) : '';
+  self && other
+    ? (((self - other) / other) * 100).toFixed(1)
+    : '';
 
 // ── main ───────────────────────────────────────────────────────────────────
 (async () => {


### PR DESCRIPTION
## Summary
- handle missing own or competitor price in `pct` helper

## Testing
- `node fetch-prices.js` *(fails to fetch prices due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684d0ff1b828832ab2179d80ae3012c0