### PR TITLE
Throttle sequential price requests

### DIFF
--- a/fetch-prices.js
+++ b/fetch-prices.js
@@ -8,6 +8,7 @@ const axios   = require('axios');
 const cheerio = require('cheerio');
 
 const DELAY_MS = 1000;   // polite 1-sec throttle
+const sleep = ms => new Promise(res => setTimeout(res, ms));
 
 // ── grab price from HTML ───────────────────────────────────────────────────
 async function getPrice(url) {
@@ -58,8 +59,11 @@ const pct = (self, other) =>
       for (const r of rows) {
         const sku   = r.sku_code;
         const pOur  = await getPrice(r.Daily_Bike);
+        await sleep(DELAY_MS);
         const pA    = await getPrice(r.Charlie);
+        await sleep(DELAY_MS);
         const pB    = await getPrice(r.Hobby_One);
+        await sleep(DELAY_MS);
         const pMC   = await getPrice(r.MC_Bike);
 
         out.push({


### PR DESCRIPTION
## Summary
- insert reusable sleep helper
- throttle between each shop price fetch

## Testing
- `node -c fetch-prices.js`

------
https://chatgpt.com/codex/tasks/task_e_684d11af08bc832abb5ffada64145f51